### PR TITLE
Update to Geocoder v3 and register named providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Geocoder for Lavarel 5
 ======================
 
-If you still use **Lavarel 4**, please check out the `0.4.x` branch [here](https://github.com/geocoder-php/GeocoderLaravel/tree/0.4.x).
+If you still use **Lavarel 4**, please check out the `0.4.x` branch [here](https://github.com/geocoder-php/GeocoderLaravel/tree/0.4.x)..
 
 This package allows you to use [**Geocoder**](http://geocoder-php.org/Geocoder/)
 in [**Laravel 5**](http://laravel.com/).

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require" : {
         "php"                 : ">=5.4",
         "illuminate/support"  : "~5.0",
-        "willdurand/geocoder" : "~2.4"
+        "willdurand/geocoder" : "~3.0"
     },
 
     "require-dev" : {

--- a/config/geocoder.php
+++ b/config/geocoder.php
@@ -13,8 +13,14 @@ return [
     // Providers get called in the chain order given here.
     // The first one to return a result will be used.
     'providers' => [
-        'Geocoder\Provider\GoogleMapsProvider' => ['fr-FR', 'Île-de-France', true],
-        'Geocoder\Provider\FreeGeoIpProvider'  => null,
+        // Named Providers
+        Geocoder\Provider\GoogleMaps::class => ['fr-FR', 'Île-de-France', true],
+        Geocoder\Provider\FreeGeoIp::class  => null,
+        // Chain Provider
+        [
+            Geocoder\Provider\GoogleMaps::class => ['fr-FR', 'Île-de-France', true],
+            Geocoder\Provider\FreeGeoIp::class  => null,
+        ]
     ],
-    'adapter'  => 'Geocoder\HttpAdapter\CurlHttpAdapter',
+    'adapter'  => Ivory\HttpAdapter\CurlHttpAdapter::class,
 ];

--- a/config/geocoder.php
+++ b/config/geocoder.php
@@ -14,13 +14,13 @@ return [
     // The first one to return a result will be used.
     'providers' => [
         // Named Providers
-        Geocoder\Provider\GoogleMaps::class => ['fr-FR', 'Île-de-France', true],
-        Geocoder\Provider\FreeGeoIp::class  => null,
+        'Geocoder\Provider\GoogleMaps' => ['fr-FR', 'Île-de-France', true],
+        'Geocoder\Provider\FreeGeoIp'  => null,
         // Chain Provider
         [
-            Geocoder\Provider\GoogleMaps::class => ['fr-FR', 'Île-de-France', true],
-            Geocoder\Provider\FreeGeoIp::class  => null,
+            'Geocoder\Provider\GoogleMaps' => ['fr-FR', 'Île-de-France', true],
+            'Geocoder\Provider\FreeGeoIp'  => null,
         ]
     ],
-    'adapter'  => Ivory\HttpAdapter\CurlHttpAdapter::class,
+    'adapter'  => 'Ivory\HttpAdapter\CurlHttpAdapter',
 ];

--- a/src/GeocoderServiceProvider.php
+++ b/src/GeocoderServiceProvider.php
@@ -11,8 +11,8 @@
 
 namespace Toin0u\Geocoder;
 
-use Geocoder\Geocoder;
-use Geocoder\Provider\ChainProvider;
+use Geocoder\ProviderAggregator;
+use Geocoder\Provider\Chain;
 
 /**
  * Geocoder service provider
@@ -49,7 +49,7 @@ class GeocoderServiceProvider extends \Illuminate\Support\ServiceProvider
         });
 
         $this->app['geocoder'] = $this->app->share(function($app) {
-            $geocoder = new Geocoder;
+            $geocoder = new ProviderAggregator;
             $geocoder->registerProviders(
                 $this->getGeocoderProviders($this->app['config']->get('geocoder.providers'))
             );
@@ -65,7 +65,7 @@ class GeocoderServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function provides()
     {
-        return ['geocoder', 'geocoder.adapter', 'geocoder.chain'];
+        return ['geocoder', 'geocoder.adapter'];
     }
     
     protected function getGeocoderProviders(array $providersConfig)
@@ -76,7 +76,7 @@ class GeocoderServiceProvider extends \Illuminate\Support\ServiceProvider
             //Chain provider
             if(is_int($provider)){
                 $chainProviders = $this->getGeocoderProviders($arguments);
-                $providers[] = new ChainProvider($chainProviders);
+                $providers[] = new Chain($chainProviders);
             }else {
                 if (0 !== count($arguments)) {
                     $providers[] = call_user_func_array(

--- a/src/GeocoderServiceProvider.php
+++ b/src/GeocoderServiceProvider.php
@@ -48,27 +48,6 @@ class GeocoderServiceProvider extends \Illuminate\Support\ServiceProvider
             return new $adapter;
         });
 
-        $this->app->singleton('geocoder.chain', function($app) {
-            $providers = [];
-
-            foreach($app['config']->get('geocoder.providers') as $provider => $arguments) {
-                if (0 !== count($arguments)) {
-                    $providers[] = call_user_func_array(
-                        function ($arg1 = null, $arg2 = null, $arg3 = null, $arg4 = null) use ($app, $provider) {
-                            return new $provider($app['geocoder.adapter'], $arg1, $arg2, $arg3, $arg4);
-                        },
-                        $arguments
-                    );
-
-                    continue;
-                }
-
-                $providers[] = new $provider($app['geocoder.adapter']);
-            }
-
-            return new ChainProvider($providers);
-        });
-
         $this->app['geocoder'] = $this->app->share(function($app) {
             $geocoder = new Geocoder;
             $geocoder->registerProviders(

--- a/tests/Facade/GeocoderTest.php
+++ b/tests/Facade/GeocoderTest.php
@@ -20,6 +20,6 @@ class GeocoderTest extends \Toin0u\Tests\Geocoder\TestCase
     {
         $this->assertTrue(is_array($providers = \Geocoder::getProviders()));
         $this->assertArrayHasKey('chain', $providers);
-        $this->assertInstanceOf('Geocoder\\Provider\\ChainProvider', $providers['chain']);
+        $this->assertInstanceOf('Geocoder\\Provider\\Chain', $providers['chain']);
     }
 }


### PR DESCRIPTION
- According to

> Major version 2 will reach end of life on December 2015

needs to update Geocoder version in composer.json.

- We can configure only chain provider. With my fix we can register named providers (and chain too), and call them with `Geocoder::using('provider_name')`.