### PR TITLE
Alias IoC key to Geocoder class for DI

### DIFF
--- a/src/GeocoderServiceProvider.php
+++ b/src/GeocoderServiceProvider.php
@@ -75,6 +75,8 @@ class GeocoderServiceProvider extends \Illuminate\Support\ServiceProvider
 
             return $geocoder;
         });
+        
+        $this->app->alias('geocoder', 'Geocoder\Geocoder');
     }
 
     /**
@@ -84,6 +86,6 @@ class GeocoderServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function provides()
     {
-        return ['geocoder', 'geocoder.adapter', 'geocoder.chain'];
+        return ['geocoder', 'geocoder.adapter', 'geocoder.chain', 'Geocoder\Geocoder'];
     }
 }


### PR DESCRIPTION
In general I prefer injecting my dependencies when possible, instead of using facades. 

Currently I can't inject `Geocoder\Geocoder` into my controller (or anywhere else) because Laravel would inject a new instance, not the one that your service provider wires up.

This pull request modified the service provider to alias `geocoder` to `Geocoder\Geocoder` and makes it DI friendly. This way I can:

```
function myControllerFunction(\Geocoder\Geocoder $geo) 
{
    // $geo is the pre-wired instance from the service provider!
}
```

Note I'm following the pattern from the AwsLaravel package:

https://github.com/aws/aws-sdk-php-laravel/blob/master/src/AwsServiceProvider.php#L53