### PR TITLE
Do not install optional packages by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,20 +23,10 @@
         }
     ],
     "require": {
-        "geocoder-php/bing-maps-provider": "dev-master@dev",
-        "geocoder-php/chain-provider": "dev-master@dev",
-        "geocoder-php/common-http": "dev-master@dev",
-        "geocoder-php/geo-plugin-provider": "dev-master@dev",
-        "geocoder-php/google-maps-provider": "dev-master@dev",
-        "geocoder-php/maxmind-binary-provider": "dev-master@dev",
-        "guzzlehttp/guzzle": "^6.2",
+        "php": "^7.0",
         "illuminate/cache": "~5.0",
         "illuminate/support": "~5.0",
-        "php": "^7.0",
-        "php-http/curl-client": "^1.7",
-        "php-http/guzzle6-adapter": "^1.1",
-        "php-http/message": "^1.5",
-        "willdurand/geocoder": "dev-master@dev"
+        "willdurand/geocoder": "^4.0"
     },
     "require-dev": {
         "doctrine/dbal": "^2.5",
@@ -44,7 +34,17 @@
         "laravel/laravel": "5.4.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~5.0",
-        "satooshi/php-coveralls" : "dev-master@dev"
+        "php-http/message": "^1.5",
+        "php-http/curl-client": "^1.7",
+        "php-http/discovery": "^1.0",
+        "guzzlehttp/psr7": "^1.4",
+        "geocoder-php/bing-maps-provider": "^4.0",
+        "geocoder-php/chain-provider": "^4.0",
+        "geocoder-php/common-http": "^4.0",
+        "geocoder-php/geo-plugin-provider": "^4.0@dev",
+        "geocoder-php/google-maps-provider": "^4.0",
+        "geocoder-php/maxmind-binary-provider": "^4.0",
+        "satooshi/php-coveralls" : "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -62,6 +62,8 @@
             "dev-master": "2.0.0-dev"
         }
     },
+    "minimum-stability": "beta",
+    "prefer-stable": true,
     "config": {
         "preferred-install": "dist",
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "guzzlehttp/psr7": "^1.4",
         "geocoder-php/chain-provider": "^4.0",
         "geocoder-php/bing-maps-provider": "^4.0",
-        "geocoder-php/geo-plugin-provider": "^4.0@dev",
+        "geocoder-php/geo-plugin-provider": "^4.0",
         "geocoder-php/google-maps-provider": "^4.0",
         "geocoder-php/maxmind-binary-provider": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,14 @@
         "php": "^7.0",
         "illuminate/cache": "~5.0",
         "illuminate/support": "~5.0",
-        "willdurand/geocoder": "^4.0"
+        "php-http/message": "^1.5",
+        "php-http/curl-client": "^1.7",
+        "guzzlehttp/psr7": "^1.4",
+        "geocoder-php/chain-provider": "^4.0",
+        "geocoder-php/bing-maps-provider": "^4.0",
+        "geocoder-php/geo-plugin-provider": "^4.0@dev",
+        "geocoder-php/google-maps-provider": "^4.0",
+        "geocoder-php/maxmind-binary-provider": "^4.0"
     },
     "require-dev": {
         "doctrine/dbal": "^2.5",
@@ -34,16 +41,6 @@
         "laravel/laravel": "5.4.*",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~5.0",
-        "php-http/message": "^1.5",
-        "php-http/curl-client": "^1.7",
-        "php-http/discovery": "^1.0",
-        "guzzlehttp/psr7": "^1.4",
-        "geocoder-php/bing-maps-provider": "^4.0",
-        "geocoder-php/chain-provider": "^4.0",
-        "geocoder-php/common-http": "^4.0",
-        "geocoder-php/geo-plugin-provider": "^4.0@dev",
-        "geocoder-php/google-maps-provider": "^4.0",
-        "geocoder-php/maxmind-binary-provider": "^4.0",
         "satooshi/php-coveralls" : "^1.0"
     },
     "autoload": {

--- a/src/Providers/GeocoderService.php
+++ b/src/Providers/GeocoderService.php
@@ -11,8 +11,6 @@
 
 use Geocoder\Laravel\Facades\Geocoder;
 use Geocoder\Laravel\ProviderAndDumperAggregator;
-use Geocoder\Provider\Chain\Chain;
-use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\Collection;
 use Illuminate\Support\ServiceProvider;
 use ReflectionClass;


### PR DESCRIPTION
Excuse my ignorance about Laravel. 

I moved packages to the dev-section because these should be selected by the user. Ie the user should decide if he/she wants to download Guzzle client or Curl client. The user should decide if we should use GoogleMaps or BingMaps etc. 

I know the tests fails on this PR but it is a start of how composer.json should look before we tag 2.0. 