### PR TITLE
Specify which cache store should be used

### DIFF
--- a/config/geocoder.php
+++ b/config/geocoder.php
@@ -9,17 +9,44 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Cache Duration
+    | Cache Settings
     |--------------------------------------------------------------------------
     |
-    | Specify the cache duration in minutes. The default approximates a forever
-    | cache, but there are certain issues with Laravel's forever caching
-    | methods that prevent us from using them in this project.
-    |
-    | Default: 9999999 (integer)
+    | Here you may define all of the cache settings.
     |
     */
-    'cache-duration' => 9999999,
+
+    'cache' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Cache Store
+        |--------------------------------------------------------------------------
+        |
+        | Specify the cache store to use for caching. The default value null will
+        | use the default cache store specified in the cache.php cofig file.
+        |
+        | Default: null
+        |
+        */
+
+        'store' => null,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Cache Duration
+        |--------------------------------------------------------------------------
+        |
+        | Specify the cache duration in minutes. The default approximates a forever
+        | cache, but there are certain issues with Laravel's forever caching
+        | methods that prevent us from using them in this project.
+        |
+        | Default: 9999999 (integer)
+        |
+        */
+
+        'duration' => 9999999,
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/ProviderAndDumperAggregator.php
+++ b/src/ProviderAndDumperAggregator.php
@@ -79,7 +79,7 @@ class ProviderAndDumperAggregator
 
     public function geocodeQuery(GeocodeQuery $query) : self
     {
-        $cacheKey = serialize($query);
+        $cacheKey = md5(serialize($query));
         $this->results = app('cache')->store(config('geocoder.cache.store', null))->remember(
             "geocoder-{$cacheKey}",
             config('geocoder.cache.duration', 0),
@@ -95,7 +95,7 @@ class ProviderAndDumperAggregator
 
     public function reverseQuery(ReverseQuery $query) : self
     {
-        $cacheKey = serialize($query);
+        $cacheKey = md5(serialize($query));
         $this->results = app('cache')->store(config('geocoder.cache.store', null))->remember(
             "geocoder-{$cacheKey}",
             config('geocoder.cache.duration', 0),
@@ -116,7 +116,7 @@ class ProviderAndDumperAggregator
 
     public function geocode(string $value) : self
     {
-        $cacheKey = str_slug(strtolower(urlencode($value)));
+        $cacheKey = md5(str_slug(strtolower(urlencode($value))));
         $this->results = app('cache')->store(config('geocoder.cache.store', null))->remember(
             "geocoder-{$cacheKey}",
             config('geocoder.cache.duration', 0),
@@ -132,7 +132,7 @@ class ProviderAndDumperAggregator
 
     public function reverse(float $latitude, float $longitude) : self
     {
-        $cacheKey = str_slug(strtolower(urlencode("{$latitude}-{$longitude}")));
+        $cacheKey = md5(str_slug(strtolower(urlencode("{$latitude}-{$longitude}"))));
         $this->results = app('cache')->store(config('geocoder.cache.store', null))->remember(
             "geocoder-{$cacheKey}",
             config('geocoder.cache.duration', 0),

--- a/src/ProviderAndDumperAggregator.php
+++ b/src/ProviderAndDumperAggregator.php
@@ -80,9 +80,9 @@ class ProviderAndDumperAggregator
     public function geocodeQuery(GeocodeQuery $query) : self
     {
         $cacheKey = serialize($query);
-        $this->results = app('cache')->remember(
+        $this->results = app('cache')->store(config('geocoder.cache.store', null))->remember(
             "geocoder-{$cacheKey}",
-            config('geocoder.cache-duration', 0),
+            config('geocoder.cache.duration', 0),
             function () use ($query) {
                 return collect($this->aggregator->geocodeQuery($query));
             }
@@ -96,9 +96,9 @@ class ProviderAndDumperAggregator
     public function reverseQuery(ReverseQuery $query) : self
     {
         $cacheKey = serialize($query);
-        $this->results = app('cache')->remember(
+        $this->results = app('cache')->store(config('geocoder.cache.store', null))->remember(
             "geocoder-{$cacheKey}",
-            config('geocoder.cache-duration', 0),
+            config('geocoder.cache.duration', 0),
             function () use ($query) {
                 return collect($this->aggregator->reverseQuery($query));
             }
@@ -117,9 +117,9 @@ class ProviderAndDumperAggregator
     public function geocode(string $value) : self
     {
         $cacheKey = str_slug(strtolower(urlencode($value)));
-        $this->results = app('cache')->remember(
+        $this->results = app('cache')->store(config('geocoder.cache.store', null))->remember(
             "geocoder-{$cacheKey}",
-            config('geocoder.cache-duration', 0),
+            config('geocoder.cache.duration', 0),
             function () use ($value) {
                 return collect($this->aggregator->geocode($value));
             }
@@ -133,9 +133,9 @@ class ProviderAndDumperAggregator
     public function reverse(float $latitude, float $longitude) : self
     {
         $cacheKey = str_slug(strtolower(urlencode("{$latitude}-{$longitude}")));
-        $this->results = app('cache')->remember(
+        $this->results = app('cache')->store(config('geocoder.cache.store', null))->remember(
             "geocoder-{$cacheKey}",
-            config('geocoder.cache-duration', 0),
+            config('geocoder.cache.duration', 0),
             function () use ($latitude, $longitude) {
                 return collect($this->aggregator->reverse($latitude, $longitude));
             }
@@ -264,7 +264,7 @@ class ProviderAndDumperAggregator
 
     protected function removeEmptyCacheEntry(string $cacheKey)
     {
-        $result = app('cache')->get($cacheKey);
+        $result = app('cache')->store(config('geocoder.cache.store', null))->get($cacheKey);
 
         if ($result && $result->isEmpty()) {
             app('cache')->forget($cacheKey);

--- a/tests/Feature/Providers/GeocoderServiceTest.php
+++ b/tests/Feature/Providers/GeocoderServiceTest.php
@@ -165,7 +165,7 @@ class GeocoderServiceTest extends UnitTestCase
 
     public function testCacheIsUsed()
     {
-        $cacheKey = str_slug(strtolower(urlencode('1600 Pennsylvania Ave NW, Washington, DC 20500, USA')));
+        $cacheKey = md5(str_slug(strtolower(urlencode('1600 Pennsylvania Ave NW, Washington, DC 20500, USA'))));
 
         $result = app('geocoder')->geocode('1600 Pennsylvania Ave NW, Washington, DC 20500, USA')
             ->get();
@@ -265,14 +265,14 @@ class GeocoderServiceTest extends UnitTestCase
 
     public function testJapaneseCharacterGeocoding()
     {
-        $cacheKey = str_slug(strtolower(urlencode('108-0075 東京都港区港南２丁目１６－３')));
+        $cacheKey = md5(str_slug(strtolower(urlencode('108-0075 東京都港区港南２丁目１６－３'))));
 
         app('geocoder')->geocode('108-0075 東京都港区港南２丁目１６－３')
             ->get();
 
         $this->assertEquals(
             $cacheKey,
-            '108-0075e69db1e4baace983bde6b8afe58cbae6b8afe58d97efbc92e4b881e79baeefbc91efbc96efbc8defbc93'
+            md5('108-0075e69db1e4baace983bde6b8afe58cbae6b8afe58d97efbc92e4b881e79baeefbc91efbc96efbc8defbc93')
         );
         $this->assertTrue(app('cache')->has("geocoder-{$cacheKey}"));
     }
@@ -304,7 +304,7 @@ class GeocoderServiceTest extends UnitTestCase
 
     public function testEmptyResultsAreNotCached()
     {
-        $cacheKey = str_slug(strtolower(urlencode('_')));
+        $cacheKey = md5(str_slug(strtolower(urlencode('_'))));
 
         Geocoder::geocode('_')->get();
 

--- a/tests/Feature/Providers/GeocoderServiceTest.php
+++ b/tests/Feature/Providers/GeocoderServiceTest.php
@@ -141,7 +141,8 @@ class GeocoderServiceTest extends UnitTestCase
 
     public function testConfig()
     {
-        $this->assertEquals(999999999, config('geocoder.cache-duration'));
+        $this->assertEquals(null, config('geocoder.cache.store'));
+        $this->assertEquals(999999999, config('geocoder.cache.duration'));
         $this->assertTrue(is_array($providers = $this->app['config']->get('geocoder.providers')));
         $this->assertCount(3, $providers);
         $this->assertArrayHasKey(GoogleMaps::class, $providers[Chain::class]);
@@ -169,8 +170,8 @@ class GeocoderServiceTest extends UnitTestCase
         $result = app('geocoder')->geocode('1600 Pennsylvania Ave NW, Washington, DC 20500, USA')
             ->get();
 
-        $this->assertTrue(app('cache')->has("geocoder-{$cacheKey}"));
-        $this->assertEquals($result, app('cache')->get("geocoder-{$cacheKey}"));
+        $this->assertTrue(app('cache')->store(config('geocoder.cache.store', null))->has("geocoder-{$cacheKey}"));
+        $this->assertEquals($result, app('cache')->store(config('geocoder.cache.store', null))->get("geocoder-{$cacheKey}"));
     }
 
     /**

--- a/tests/config/testConfig.php
+++ b/tests/config/testConfig.php
@@ -16,7 +16,10 @@ use GeoIp2\Database\Reader;
 use Http\Client\Curl\Client;
 
 return [
-    'cache-duration' => 999999999,
+    'cache' => [
+        'store' => null,
+        'duration' => 999999999,
+    ],
     'providers' => [
         Chain::class => [
             GeoIP2::class => [],


### PR DESCRIPTION
## Details

- Added a feature which allows users to specify a cache store other than the apps default cache.
- The cache key should not only be serialized, it should also be hashed. Some cache stores have a limited key length, for example the database store has a key length of 255 characters. The md5 hash function seems to be pretty good for this purpose, since it hashes fast and produces a string of 32 characters.