### PR TITLE
Resolve Geocoder dependency via Class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,19 @@ app('geocoder')->reverse(43.882587,-103.454067)->get();
 app('geocoder')->geocode('Los Angeles, CA')->dump('kml');
 ```
 
+#### Using Controller
+```php
+use Geocoder\Laravel\ProviderAndDumperAggregator as Geocoder;
+
+class GeocoderController extends Controller
+{
+    public function getGeocode(Geocoder $geocoder)
+    {
+       $geocoder->geocode('Los Angeles, CA')->get()
+    }
+}
+```
+
 ## Upgrading
 Anytime you upgrade this package, please remember to clear your cache, to prevent incompatible cached responses when breaking changes are introduced (this should hopefully only be necessary in major versions):
 ```sh


### PR DESCRIPTION
The PR will enable resolving dependency via class name. This is a minor fix and will not break any existing code.

At the moment, `app('geocoder')` is the only way to resolve the geocoder dependency and does not support dependency injection via controller. 

The PR will allow the following:

```php

namespace App\Http\Controllers;

use Geocoder\Laravel\ProviderAndDumperAggregator as Geocoder;

class GeocoderController extends Controller
{
    /**
     * Create a new controller instance.
     *
     * @return void
     */
    public function __construct(Geocoder $geocoder)
    {
         $this->geocoder = $geocoder;
    }

    public function index(Geocoder $geocoder)
    {
        //
    }
}
```
The PR also tests friendy as it will allow developer to swap dependency when needed.

```php
$mock = \Mockery::mock(ProviderAndDumperAggregator::class);

$this->app->instance(ProviderAndDumperAggregator::class, $mock);
```