### PR TITLE
Prevent GeocoderService from instantiating providers on boot

### DIFF
--- a/src/Providers/GeocoderService.php
+++ b/src/Providers/GeocoderService.php
@@ -25,19 +25,16 @@ class GeocoderService extends ServiceProvider
             "config"
         );
         $this->mergeConfigFrom($configPath, "geocoder");
-        $geocoder = (new ProviderAndDumperAggregator)
-            ->registerProvidersFromConfig(collect(config("geocoder.providers")));
-        $this->app
-            ->singleton("geocoder", function () use ($geocoder) {
-                return $geocoder;
-            });
-        $this->app
-            ->instance(ProviderAndDumperAggregator::class, $geocoder);
     }
 
     public function register()
     {
         $this->app->alias("Geocoder", Geocoder::class);
+        $this->app->singleton(ProviderAndDumperAggregator::class, function () {
+            return (new ProviderAndDumperAggregator)
+                ->registerProvidersFromConfig(collect(config("geocoder.providers")));
+        });
+        $this->app->bind('geocoder', ProviderAndDumperAggregator::class);
     }
 
     public function provides() : array


### PR DESCRIPTION
The current code creates an instance of each configured provider directly in the boot method (side effect of `registerProvidersFromConfig`), this is not good practice as most likely this library won't be used on every request.

In my case it would cause a bigger issue as we do `composer install` before having a `.env` file created, and this issue would cause `artisan discover` to fail as it was trying to instantiate some providers without an API key.