### PR TITLE
Don't pass null to adapter

### DIFF
--- a/src/ProviderAndDumperAggregator.php
+++ b/src/ProviderAndDumperAggregator.php
@@ -219,14 +219,13 @@ class ProviderAndDumperAggregator
         }
 
         $adapter = $this->getAdapterClass($provider);
-        $reader = null;
 
         if ($adapter) {
             if ($this->requiresReader($provider)) {
-                $reader = config('geocoder.reader');
+                array_unshift($arguments, new $adapter(config('geocoder.reader')));
+            } else {
+                array_unshift($arguments, new $adapter());
             }
-
-            array_unshift($arguments, new $adapter($reader));
         }
 
         return $arguments;


### PR DESCRIPTION
Hello,

I had this issue with Guzzle.

Guzzle expects an array to its constructor, but here we were passing null.

This PR fixes that issue.