### PR TITLE
Require Laravel 5.x or 6.x instead of 5.0 - 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "geocoder-php/google-maps-provider": "^4.0",
         "guzzlehttp/psr7": "*",
         "http-interop/http-factory-guzzle": "^1.0",
-        "illuminate/cache": "5.0 - 6.0",
-        "illuminate/support": "5.0 - 6.0",
+        "illuminate/cache": "^5.0|^6.0",
+        "illuminate/support": "^5.0|^6.0",
         "php-http/curl-client": "*",
         "php": ">=7.1.3",
         "willdurand/geocoder": "^4.0"


### PR DESCRIPTION
I changed the Laravel version range from '5.0 - 6.0' to '^5.0|^6.0' which seems to be what @mikebronner intended to do in #156. Laravel is following semver now, so requiring '^6.0' should be fine. This fixes #160.