### PR TITLE
Allow passing reader class and arguments as array

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ return [
     |
     | You can specify a reader for specific providers, like GeoIp2, which
     | connect to a local file-database. The reader should be set to an
-    | instance of the required reader class.
+    | instance of the required reader class or an array containing the reader
+    | class and arguments.
     |
     | Please consult the official Geocoder documentation for more info.
     | https://github.com/geocoder-php/geoip2-provider

--- a/config/geocoder.php
+++ b/config/geocoder.php
@@ -88,7 +88,8 @@ return [
     |
     | You can specify a reader for specific providers, like GeoIp2, which
     | connect to a local file-database. The reader should be set to an
-    | instance of the required reader class.
+    | instance of the required reader class or an array containing the reader
+    | class and arguments.
     |
     | Please consult the official Geocoder documentation for more info.
     | https://github.com/geocoder-php/geoip2-provider

--- a/src/ProviderAndDumperAggregator.php
+++ b/src/ProviderAndDumperAggregator.php
@@ -221,6 +221,18 @@ class ProviderAndDumperAggregator
         return config('geocoder.adapter');
     }
 
+    protected function getReader()
+    {
+        if (is_array(config('geocoder.reader'))) {
+            $reflection = new ReflectionClass(config('geocoder.reader.class'));
+            $reader = $reflection->newInstanceArgs(config('geocoder.reader.arguments'));
+        } else {
+            $reader = config('geocoder.reader');
+        }
+
+        return $reader;
+    }
+
     protected function getArguments(array $arguments, string $provider) : array
     {
         if ($provider === 'Geocoder\Provider\Chain\Chain') {
@@ -232,9 +244,11 @@ class ProviderAndDumperAggregator
         $adapter = $this->getAdapterClass($provider);
 
         if ($adapter) {
-            $adapter = $this->requiresReader($provider)
-                ? new $adapter(config('geocoder.reader'))
-                : new $adapter;
+            if ($this->requiresReader($provider)) {
+                $adapter = new $adapter($this->getReader());
+            } else {
+                $adapter = new $adapter;
+            }
 
             array_unshift($arguments, $adapter);
         }


### PR DESCRIPTION
Laravel does not support closures within the config files (https://github.com/laravel/framework/issues/9625), and so setting the `geocoder.reader` configuration to an instance of `\GeoIp2\Database\Reader` or `\GeoIp2\WebService\Client` created problems when running `php artisan config:cache`.

With the changes I made, you could configure the `reader` like so:

```
    'reader' => [
        'class' => WebService::class,
        'arguments' => [env('MAXMIND_USER_ID'), env('MAXMIND_LICENSE_KEY')],
    ],
```

It also still supports the old method of setting the reader instance:

```
    'reader' => new WebService(
        env('MAXMIND_USER_ID'),
        env('MAXMIND_LICENSE_KEY')
    ),
```