### PR TITLE
Fixed remove empty cache entry method

### DIFF
--- a/src/ProviderAndDumperAggregator.php
+++ b/src/ProviderAndDumperAggregator.php
@@ -320,7 +320,9 @@ class ProviderAndDumperAggregator
     protected function removeEmptyCacheEntry(Collection $result, string $cacheKey)
     {
         if ($result && $result->isEmpty()) {
-            app('cache')->forget($cacheKey);
+            app('cache')
+                ->store(config('geocoder.cache.store'))
+                ->forget($cacheKey);
         }
     }
 


### PR DESCRIPTION
It didn't actually remove the cache entry because cache store was not specified.