### PR TITLE
Use service container to instantiate adapter

### DIFF
--- a/src/ProviderAndDumperAggregator.php
+++ b/src/ProviderAndDumperAggregator.php
@@ -265,7 +265,7 @@ class ProviderAndDumperAggregator
             if ($this->requiresReader($provider)) {
                 $adapter = new $adapter($this->getReader());
             } else {
-                $adapter = new $adapter;
+                $adapter = app($adapter);
             }
 
             array_unshift($arguments, $adapter);


### PR DESCRIPTION
This allows you to specify how the adapter should be instantiated. You could, for example, set Guzzle options or use a different adapter in tests, to mock requests.

```php
$this->app->bind(\Http\Client\HttpClient::class, function ($app) {
    if ($app->environment('testing')) {
        return new \Swis\Http\Fixture\Client(
            new \Swis\Http\Fixture\ResponseBuilder('/path/to/fixtures')
        );
    } else {
        return \Http\Adapter\Guzzle7\Client::createWithConfig(
            [
                'timeout' => 2,
            ]
        );
    }
});
```

N.B. This example uses our [swisnl/php-http-fixture-client](https://github.com/swisnl/php-http-fixture-client) when in testing environment. This package allows you to easily mock requests with static fixtures. Definitely worth a try!