### PR TITLE
Remove use of `Str::slug` when building reverse geocoding cache key

### DIFF
--- a/src/ProviderAndDumperAggregator.php
+++ b/src/ProviderAndDumperAggregator.php
@@ -168,7 +168,7 @@ class ProviderAndDumperAggregator
 
     public function reverse(float $latitude, float $longitude) : self
     {
-        $cacheKey = (new Str)->slug(strtolower(urlencode("{$latitude}-{$longitude}")));
+        $cacheKey = strtolower(urlencode("{$latitude}-{$longitude}"));
         $this->results = $this->cacheRequest($cacheKey, [$latitude, $longitude], "reverse");
 
         return $this;


### PR DESCRIPTION
Use of `Str::slug` when building reverse geocoding cache key was redundant as the characters allowed in the cache are already controller. This fixes a bug where geolocation with opposites lat/lngs (45/73 vs -45/73 vs 45/-73 vs -45/-73) would all have the same cache key.

This fixes issue #203.